### PR TITLE
 開発用DBを爆速でセットアップするファイル追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ $ brew cask install docker
 
 Linux
 ```sh
-curl https://get.docker.com | sh
-sudo usermod -aG docker $USER
-sudo systemctl start docker
-sudo systemctl enable docker
-sudo curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+$ curl https://get.docker.com | sh
+$ sudo usermod -aG docker $USER
+$ sudo systemctl start docker
+$ sudo systemctl enable docker
+$ sudo curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+$ sudo chmod +x /usr/local/bin/docker-compose
 ```
 
 2. `mysql`のインストール
@@ -75,6 +75,8 @@ $ sudo apt install mysql-server mysql-client
 
 
 ### db_setupの使い方
+
+#### DBの作成
 
 1. `docker-compose.yml`があるディレクトリに移動する
 
@@ -146,4 +148,22 @@ Database changed
 /* tableを表示する */
 mysql> show tables;
 Empty set (0.02 sec)
+```
+
+#### DBの削除
+
+1. `docker-compose.yml`があるディレクトリに移動する
+
+```sh
+$ cd db_setup
+```
+
+2. コンテナを削除する
+
+```sh
+$ docker-compose down
+
+Stopping todotweet_db ... done
+Removing todotweet_db ... done
+Removing network db_setup_default
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,34 @@ go version go1.13.5 darwin/amd64
 ### 準備
 
 1. `docker`と`docker-compose`のインストール
+
+Mac
+```sh
+$ brew install docker
+$ brew cask install docker
+```
+
+Linux
+```sh
+curl https://get.docker.com | sh
+sudo usermod -aG docker $USER
+sudo systemctl start docker
+sudo systemctl enable docker
+sudo curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
 2. `mysql`のインストール
+
+Mac
+```sh
+$ brew install mysql
+```
+Linux
+```sh
+$ sudo apt install mysql-server mysql-client
+```
+
 
 ### db_setupの使い方
 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,86 @@ set -x PATH $PATH $GOPATH/bin
 $ go version
 go version go1.13.5 darwin/amd64
 ```
+
+---
+
+## MySQLの環境構築
+
+### 準備
+
+1. `docker`と`docker-compose`のインストール
+2. `mysql`のインストール
+
+### db_setupの使い方
+
+1. `docker-compose.yml`があるディレクトリに移動する
+
+```sh
+$ cd db_setup
+```
+
+2. `docker-compose.yml`を元にコンテナを起動する
+```sh
+$ docker-compose up -d
+
+Creating network "db_setup_default" with the default driver
+Creating todotweet_db ... done
+```
+
+3. コンテナが起動できているか確認する
+```sh
+$ docker-compose ps
+
+    Name                 Command             State                 Ports              
+--------------------------------------------------------------------------------------
+todotweet_db   docker-entrypoint.sh mysqld   Up      0.0.0.0:3306->3306/tcp, 33060/tcp
+```
+
+4. DBサーバーにアクセスできるか確認する
+```sh
+$ mysql -u root -p -h 127.0.0.1 -P 3306
+
+# パスワードを要求されるので、入力（デフォルトはpassword）
+Enter password:
+
+# 下記のような出力があればOK
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 8
+Server version: 8.0.18 MySQL Community Server - GPL
+
+Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql> 
+```
+
+5. `todotweet_db`というDBが作成されているか確認する
+
+```sql
+mysql> show databases;
++--------------------+
+| Database           |
++--------------------+
+| information_schema |
+| mysql              |
+| performance_schema |
+| sys                |
+| todotweet_db       |
++--------------------+
+5 rows in set (0.01 sec)
+```
+
+6. `todotweet_db`に切り替えて、tableを確認する
+```sql
+/* 使用するDBを切り替える */
+mysql> use todotweet_db;
+Database changed
+/* tableを表示する */
+mysql> show tables;
+Empty set (0.02 sec)
+```

--- a/db_setup/.env
+++ b/db_setup/.env
@@ -1,0 +1,5 @@
+DB_NAME=todotweet_db
+DB_USER=root
+DB_PASS=password
+DB_PORT=3306
+TZ=Asia/Tokyo

--- a/db_setup/docker-compose.yml
+++ b/db_setup/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  db:
+    image: mysql:latest
+    container_name: todotweet_db
+    restart: always
+    # 環境変数（.envから参照させる）
+    environment:
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_USER=${DB_USER}
+      - MYSQL_PASSWORD=${DB_PASS}
+      - MYSQL_ROOT_PASSWORD=${DB_PASS}
+      - TZ=${TZ}
+    # ホストport:コンテナport
+    ports:
+      - ${DB_PORT}:3306


### PR DESCRIPTION
#18 #15 ←対応issue
本来は1issue-1branchで作るべきですが、関連の強いissueなので、同一ブランチのほうが議論しやすいと思って上記の2issueと対応させてます。

- このブランチをローカルに作って、readmeの手順でDBサーバーをコンテナとして起動して、mysqlコマンドでDBにアクセス＆sql操作できたら、conversationでレスください（当方のローカル環境では動作確認済です）
- `.env`でDBの設定（user名やpasswordなど）は変更できるので、自由に変更して使用してください（変更した場合はDBにアクセスするときのmysqlコマンドがreadmeで記載したものとは変わるので注意）