### PR TITLE
echoを導入して、ブラウザから`hello, word`を出力させるAPIを作成する

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,0 +1,12 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo"
+)
+
+// Hello, Worldを返す関数
+func Hello(c echo.Context) error {
+	return c.String(http.StatusOK, "Hello, World!")
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,28 @@
 package main
 
-import "fmt"
+import (
+	// controllerパッケージをimport
+	"./controller"
 
+	// go get "github.com/dgrijalva/jwt-go" を実行して事前に取得しとく
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
+)
+
+// エンドポイント（ここから処理が始まる）
 func main() {
-	fmt.Println("hello, world")
+	// Echoのインスタンス作る
+	e := echo.New()
+
+	// ログを吐かせるミドルウェア
+	e.Use(middleware.Logger())
+	// panicが発生したときにサーバーを維持するミドルウェア
+	e.Use(middleware.Recover())
+
+	// pathと関数の紐付け（ルーティング）
+	// http://localhost:1323/hello を叩くとHelloが呼ばれる
+	e.GET("/hello", controller.Hello)
+
+	// サーバー起動(ここでportを指定する)
+	e.Start(":1323")
 }


### PR DESCRIPTION
#14 ←対応issue

動作確認の流れ

- ローカルにこのブランチを作成
- `go get "github.com/dgrijalva/jwt-go"`を実行して必要なパッケージを取得する
- `go run main.go`を実行してechoサーバーを起動する
- ブラウザ（curlコマンドでも可）で下記のurlを叩いて`Hello, world`を出力させる
  - http://localhost:1323/hello

動作確認ができたら、conversationにレスをお願いします