### PR TITLE
環境構築手順の修正(#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,6 @@ $ sudo curl -L https://github.com/docker/compose/releases/download/1.16.1/docker
 $ sudo chmod +x /usr/local/bin/docker-compose
 ```
 
-2. `mysql`のインストール
-
-Mac
-```sh
-$ brew install mysql
-```
-Linux
-```sh
-$ sudo apt install mysql-server mysql-client
-```
-
-
 ### db_setupの使い方
 
 #### DBの作成
@@ -106,7 +94,7 @@ todotweet_db   docker-entrypoint.sh mysqld   Up      0.0.0.0:3306->3306/tcp, 330
 
 4. DBサーバーにアクセスできるか確認する
 ```sh
-$ mysql -u root -p -h 127.0.0.1 -P 3306
+$ docker exec -it todotweet_db mysql -u root -p -h 127.0.0.1 -P 3306
 
 # パスワードを要求されるので、入力（デフォルトはpassword）
 Enter password:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ $ brew install go
 
 Linux
 ```sh
-$ sudo apt install golang-go
+# https://golang.org/dl/ から最新バージョンを確認
+$ cd ~/
+$ wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz
+$ tar -C ./ -xzf go1.13.5.linux-amd64.tar.gz
 ```
 
 2. PATHを通す


### PR DESCRIPTION
以下2点の修正案です。

- linux環境におけるgolangのインストール手順
  - aptで降ってくるバージョンが古いことがあるので、最新バージョンを導入する手順に変更

- mysqlインストールの手順を削除
  - dockerでmysqlコンテナを作成しているのでホストにmysqlはインストールしなくても大丈夫(なはず)