### PR TITLE
DBの設定をconfig.jsonから参照させる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 .DS_Store
 .env
+config.json

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+)
+
+// 構造体定義
+type DBConfig struct {
+	DBMS     string `json:"dbms"`
+	User     string `json:"user"`
+	Password string `json:"password"`
+	Protocol string `json:"protocol"`
+	DBName   string `json:"db_name"`
+}
+
+func DecodeJson() DBConfig {
+
+	jsonString, err := ioutil.ReadFile("config.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cf := DBConfig{}
+	json.Unmarshal(jsonString, &cf)
+	return cf
+
+}

--- a/model/db.go
+++ b/model/db.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	conf "api-server/config"
+	
 	// gormパッケージ
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
@@ -10,12 +12,15 @@ import (
 
 func InitDB() *gorm.DB {
 
+	// デコードしたjsonをcfに格納
+	cf := conf.DecodeJson()
+
 	// DBサーバーの情報
-	DBMS := "mysql"
-	user := "root"
-	password := "password"
-	protocol := "tcp(127.0.0.1:3306)"
-	DBname := "todotweet_db"
+	DBMS := cf.DBMS
+	user := cf.User
+	password := cf.Password
+	protocol := cf.Protocol
+	DBname := cf.DBName
 
 	DBInfo := user + ":" + password + "@" + protocol + "/" + DBname + "?parseTime=true"
 


### PR DESCRIPTION
#30 ←対応issue

動作確認の手順

- 下記のテンプレを参考にconfig.jsonを作成してプロジェクトルート（直下）に配置する
  - https://github.com/op19-it-edu/api-server/wiki/config.json_template
- DBサーバーを起動する
- APIサーバーを起動する
- Postman等でAPIを叩いて動作確認
  - environmentとcollectionをimportして設定環境を再現すると楽です

特にAPIの実装はいじっていないので、動作確認手順は #32 と一緒です