### PR TITLE
ルーティング用のパッケージを外だしする

### DIFF
--- a/route/router.go
+++ b/route/router.go
@@ -1,0 +1,34 @@
+package route
+
+import (
+	ctr "api-server/controller"
+
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
+)
+
+func NewRouter() *echo.Echo {
+
+	// Echoのインスタンス作る
+	e := echo.New()
+
+	// ログを吐かせるミドルウェア
+	e.Use(middleware.Logger())
+	// panicが発生したときにサーバーを維持するミドルウェア
+	e.Use(middleware.Recover())
+
+	// 以下、pathとhandler関数の紐付け（ルーティング）
+
+	// 認証なし
+	e.POST("/signup", ctr.SignUp)
+
+	api := e.Group("/api/v1")
+
+	// 以下、JWT認証が必要
+	api.GET("/users", ctr.GetAccounts)
+	api.GET("/user/:uid", ctr.GetAccount)
+	api.PUT("/user/:uid", ctr.UpdateAccount)
+	api.DELETE("/user/:uid", ctr.DeleteAccount)
+
+	return e
+}

--- a/server.go
+++ b/server.go
@@ -1,13 +1,8 @@
 package main
 
 import (
-	// controllerパッケージをimportしてctrというエイリアスをつける（使用するとき長いので）
-	ctr "api-server/controller"
 	m "api-server/model"
-
-	// go get "github.com/dgrijalva/jwt-go" を実行して事前に取得しとく
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	r "api-server/route"
 )
 
 // ルーティング設定とサーバーの起動を定義
@@ -18,26 +13,8 @@ func main() {
 	// migrationを実行
 	m.MigrateDB()
 
-	// Echoのインスタンス作る
-	e := echo.New()
-
-	// ログを吐かせるミドルウェア
-	e.Use(middleware.Logger())
-	// panicが発生したときにサーバーを維持するミドルウェア
-	e.Use(middleware.Recover())
-
-	// 以下、pathとhandler関数の紐付け（ルーティング）
-
-	// 認証なし
-	e.POST("/signup", ctr.SignUp)
-
-	api := e.Group("/api/v1")
-
-	// 以下、JWT認証が必要
-	api.GET("/users", ctr.GetAccounts)
-	api.GET("/user/:uid", ctr.GetAccount)
-	api.PUT("/user/:uid", ctr.UpdateAccount)
-	api.DELETE("/user/:uid", ctr.DeleteAccount)
+	//  ルーティングを設定
+	e := r.NewRouter()
 
 	// サーバー起動(ここでportを指定する)
 	e.Start(":1323")


### PR DESCRIPTION
#39 ←対応issue

### 変更点
server.go内のルーティング部分をrouteパッケージとして外だし

### 目的
- sever.goの肥大化を防ぐため
  - サーバーの起動に専念させる
- ルーティング設定箇所の検索性向上のため

### 動作確認の手順
APIの実装はいじってないので、現状最新のmasterと同じです