### PR TITLE
relation機能の作成(#26)

### DIFF
--- a/controller/relation.go
+++ b/controller/relation.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	"net/http"
+
+	// modelパッケージをimportしてmというエイリアスをつける
+	m "api-server/model"
+
+	"strconv"
+
+	"github.com/labstack/echo"
+)
+
+func CreateRelation(c echo.Context) error {
+
+	// jwtからuserIDを取り出す
+	userID := UserIdFromToken(c)
+
+	// requestから受け取った値を変数に格納する
+	followeeID, _ := strconv.Atoi(c.Param("id"))
+
+	// followeeIDがDBに無ければエラーを返す
+	if followee := m.GetUser(followeeID); followee.ID == 0 {
+		return &echo.HTTPError{
+			Code:    http.StatusBadRequest,
+			Message: "user not found",
+		}
+	}
+
+	castedLoginUserID := uint(userID)
+	castedFolloweeID := uint(followeeID)
+	// RelationsテーブルのuserIDにはLoginUserIDを、followIDにはFolloweeIDを保存
+	m.CreateRelation(castedLoginUserID, castedFolloweeID)
+
+	return c.JSON(http.StatusOK, "creating relation succeeded")
+}
+
+func GetFollowee(c echo.Context) error {
+
+	// requestから受け取った値を変数に格納する
+	targetUserID, _ := strconv.Atoi(c.Param("id"))
+
+	// targetUserIDがDBに無ければエラーを返す
+	if targetUser := m.GetUser(targetUserID); targetUser.ID == 0 {
+		return &echo.HTTPError{
+			Code:    http.StatusBadRequest,
+			Message: "user not found",
+		}
+	}
+
+	castedID := uint(targetUserID)
+	followeeIDs := m.GetFolloweeID(castedID)
+	followee := m.GetRelators(followeeIDs)
+
+	return c.JSON(http.StatusOK, followee)
+}
+
+func GetFollower(c echo.Context) error {
+
+	// requestから受け取った値を変数に格納する
+	targetUserID, _ := strconv.Atoi(c.Param("id"))
+
+	// targetUserIDがDBに無ければエラーを返す
+	if targetUser := m.GetUser(targetUserID); targetUser.ID == 0 {
+		return &echo.HTTPError{
+			Code:    http.StatusBadRequest,
+			Message: "user not found",
+		}
+	}
+
+	castedID := uint(targetUserID)
+	followerIDs := m.GetFollowerID(castedID)
+	follower := m.GetRelators(followerIDs)
+
+	return c.JSON(http.StatusOK, follower)
+}
+
+func DeleteRelation(c echo.Context) error {
+
+	// jwtからuserIDを取り出す
+	userID := UserIdFromToken(c)
+
+	// requestから受け取った値を変数に格納する
+	followeeID, _ := strconv.Atoi(c.Param("id"))
+
+	// followeeIDがDBに存在しない場合はエラーを返す
+	if followee := m.GetUser(followeeID); followee.ID == 0 {
+		return &echo.HTTPError{
+			Code:    http.StatusBadRequest,
+			Message: "user not found",
+		}
+	}
+
+	castedLoginUserID := uint(userID)
+	castedFolloweeID := uint(followeeID)
+	m.DeleteRelation(castedLoginUserID, castedFolloweeID)
+
+	return c.JSON(http.StatusOK, "deleting relation succeeded")
+}

--- a/model/db.go
+++ b/model/db.go
@@ -43,7 +43,7 @@ func MigrateDB() {
 
 	db.AutoMigrate(&User{})
 	// AddForeignKey()で外部キーを指定
-	db.AutoMigrate(&Relation{}).AddForeignKey("user_id", "users(id)", "RESTRICT", "RESTRICT").AddForeignKey("follow_id", "users(id)", "RESTRICT", "RESTRICT")
+	db.AutoMigrate(&Relation{}).AddForeignKey("user_id", "users(id)", "CASCADE", "CASCADE").AddForeignKey("follow_id", "users(id)", "CASCADE", "CASCADE")
 	db.AutoMigrate(&TodoTweet{}).AddForeignKey("user_id", "users(id)", "RESTRICT", "RESTRICT")
 
 	// DBを閉じる

--- a/model/entity.go
+++ b/model/entity.go
@@ -27,11 +27,11 @@ type Relation struct {
 	gorm.Model
 
 	// 外部キー（usersテーブル）
-	UserID   uint
-	FollowID uint
+	UserID   uint `gorm:"not null"`
+	FollowID uint `gorm:"not null"`
 }
 
-// todo_tweetsテーブル
+// todo_tweetsテーブルs
 type TodoTweet struct {
 	gorm.Model
 

--- a/model/relation.go
+++ b/model/relation.go
@@ -1,0 +1,81 @@
+package model
+
+func CreateRelation(loginUserID, targetFolloweeID uint) {
+
+	db := InitDB()
+	relation := Relation{
+		UserID:   loginUserID,
+		FollowID: targetFolloweeID,
+	}
+
+	db.Create(&relation)
+
+	defer db.Close()
+
+}
+
+func GetFolloweeID(targetUserID uint) []int {
+
+	db := InitDB()
+	followee := []Relation{}
+
+	// 該当ユーザーのfolloweeを取り出す
+	db.Where("user_id = ?", targetUserID).Find(&followee)
+
+	defer db.Close()
+
+	// 構造体からFolloweeIDを取り出す
+	followeeIDs := make([]uint, len(followee))
+	for i, v := range followee {
+		followeeIDs[i] = v.FollowID
+	}
+
+	// 取り出したFolloweeIDをintに変換
+	castedIDs := make([]int, len(followeeIDs))
+	for n := range followeeIDs {
+		castedIDs[n] = int(followeeIDs[n])
+	}
+
+	return castedIDs
+
+}
+
+func GetFollowerID(loginUserID uint) []int {
+
+	db := InitDB()
+	follower := []Relation{}
+
+	// 該当ユーザーのfolloweeを取り出す
+	db.Where("follow_id = ?", loginUserID).Find(&follower)
+
+	defer db.Close()
+
+	// 構造体からFolloweeIDを取り出す
+	followerIDs := make([]uint, len(follower))
+	for i, v := range follower {
+		followerIDs[i] = v.UserID
+	}
+
+	// 取り出したFolloweeIDをintに変換
+	castedIDs := make([]int, len(followerIDs))
+	for n := range followerIDs {
+		castedIDs[n] = int(followerIDs[n])
+	}
+
+	return castedIDs
+
+}
+
+func DeleteRelation(loginUserID, targetFolloweeID uint) {
+
+	db := InitDB()
+	relation := Relation{
+		UserID:   loginUserID,
+		FollowID: targetFolloweeID,
+	}
+
+	db.Unscoped().Delete(relation, "user_id LIKE ? AND follow_id LIKE ?", relation.UserID, relation.FollowID)
+
+	defer db.Close()
+
+}

--- a/model/user.go
+++ b/model/user.go
@@ -53,6 +53,22 @@ func GetUser(uid int) User {
 
 }
 
+// userIDが一致するレコード全てを返す(fllowee, followerを返すため)
+func GetRelators(IDs []int) []User {
+	db := InitDB()
+	users := []User{}
+
+	for _, v := range IDs {
+		user := User{}
+		db.Where("id = ?", v).Find(&user)
+		user.UserPassword = ""
+		users = append(users, user)
+	}
+
+	return users
+
+}
+
 func UpdateUser(uid int, name, password, description string) {
 
 	db := InitDB()
@@ -78,7 +94,6 @@ func DeleteUser(uid int) {
 	user.ID = castedID
 
 	db.Unscoped().Delete(&user)
-	// db.Model(&user).Where("id = ?", uid).Delete(&user)
 
 	defer db.Close()
 

--- a/postman/api-server.postman_collection.json
+++ b/postman/api-server.postman_collection.json
@@ -239,6 +239,138 @@
 			"response": []
 		},
 		{
+			"name": "CreateRelation",
+			"request": {
+				"method": "POST",
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/x-www-form-urlencoded",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://{{host}}:{{port}}/api/v1/relation/2",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"relation",
+						"2"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "DeleteRelation",
+			"request": {
+				"method": "DELETE",
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"header": [],
+				"url": {
+					"raw": "http://{{host}}:{{port}}/api/v1/relation/2",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"relation",
+						"2"
+					]
+				}
+			}
+		},
+		{
+			"name": "GetFollowee",
+			"request": {
+				"method": "GET",
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"header": [],
+				"url": {
+					"raw": "http://{{host}}:{{port}}/api/v1/followee/1",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"followee",
+						"1"
+					]
+				}
+			}
+		},
+		{
+			"name": "GetFollower",
+			"request": {
+				"method": "GET",
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"header": [],
+				"url": {
+					"raw": "http://{{host}}:{{port}}/api/v1/follower/2",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"follower",
+						"2"
+					]
+				}
+			}
+		},
+		{
 			"name": "GetAccount",
 			"request": {
 				"method": "GET",

--- a/route/router.go
+++ b/route/router.go
@@ -36,6 +36,11 @@ func NewRouter() *echo.Echo {
 
 	// followeeを検索するため全ユーザーを返す
 	api.GET("/users", ctr.GetAllAccounts)
+	// followeeを新規作成する
+	api.POST("/relation/:id", ctr.CreateRelation)
+	api.DELETE("/relation/:id", ctr.DeleteRelation)
+	api.GET("/followee/:id", ctr.GetFollowee)
+	api.GET("/follower/:id", ctr.GetFollower)
 
 	// 該当ユーザー情報を表示するため(後々、該当ユーザーのtodoも返す)
 	api.GET("/user/:id", ctr.GetAccount)


### PR DESCRIPTION
#26  
↑issue番号

 `show create table relations;` 
FK制約は `desc relations;` では確認できないので、上記コマンドで確認してください。

- postmanのcollectionと使った動作確認
  - userを2名signupさせる
    - 2人目をsignupさせるときは、postmanのbodyを`user_2`とかに書き換えて、postする
  - IDが1のユーザーでloginする
    - 返却されたjwtをコピーしておいて、後ほど叩くそれぞれの `api/v1/` で使用する
  - relationをcreateするためにpostする
    -  `user_id = 1` のユーザに `user_id = 2` のユーザを `followee` として追加する
      - この時、 `Authrization` で `Type` の中から `Barer Token` を選択して、コピーしておいたjwtをペーストする
        - 下記のそれぞれのapiを叩く時にもこの操作を逐一する
    - ありえない `user_id` 例えば、 `user_id = 100` とかで遊んでみてもいい
  - followeeを確認する
    - この時に、jwtなしで叩いて遊んでもいい
  - followerを確認する
    -  `user_id = 2` のfollowerには `user_id = 1` がいるはずなので、 `/api/v1/follower/2` でGETする
  - relationを削除してみる
  - userを削除すれば、relationテーブルからも該当ユーザ情報がすべて削除されることを確認する
    - 事前にもう一度relationを作っておく必要あり

- 参考ページ
  - [MySQLの外部キー制約RESTRICT,CASCADE,SET NULL,NO ACTIONの違いは？](https://qiita.com/suin/items/21fe6c5a78c1505b19cb)
  - [How treat cascade operation with GORM (Go)](https://stackoverflow.com/questions/36456019/how-treat-cascade-operation-with-gorm-go)